### PR TITLE
Ww 507 fix dropdown hover hidden conditions on slide origin and rotate properties

### DIFF
--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -129,8 +129,11 @@ export default {
     },
     watch: {
         /* wwEditor:start */
-        content() {
-            this.updatePosition();
+        content: {
+            deep: true,
+            handler: function () {
+                this.updatePosition();
+            }
         },
         isEditing() {
             if (!this.isEditing) {
@@ -165,6 +168,9 @@ export default {
                 this.states = [];
             }
         });
+    },
+    mounted() {
+        this.updatePosition()
     },
     unmounted() {
         wwLib.$off('ww-hover-dropdown:opened');
@@ -216,7 +222,6 @@ export default {
 
 .dropdown {
     position: relative;
-    z-index: 10000 !important;
 
     .dropdown-default {
         perspective: var(--perspective);
@@ -228,10 +233,9 @@ export default {
         flex-direction: row;
         justify-content: center;
         align-items: center;
-        z-index: 10000;
     }
     &__content {
-        z-index: 9999;
+        z-index: 100;
         position: fixed;
         top: var(--top-position);
         left: 50%;
@@ -252,7 +256,6 @@ export default {
         }
     }
     &__content.under {
-        z-index: 9999;
         position: absolute;
         top: 100%;
 

--- a/ww-config.js
+++ b/ww-config.js
@@ -64,7 +64,7 @@ export default {
             },
             section: 'settings',
             hidden: content => {
-                return content.appearAnimation === 'slideX' || content.appearAnimation === 'slideY';
+                return !['slideX', 'slideY'].includes(content.appearAnimation);
             },
             options: {
                 unitChoices: [{ value: 'px', label: 'px', min: -300, max: 300 }],
@@ -79,7 +79,7 @@ export default {
             },
             section: 'settings',
             hidden: content => {
-                return content.appearAnimation === 'rotate';
+                return content.appearAnimation !== 'rotate';
             },
             options: {
                 unitChoices: [{ value: 'deg', label: 'deg', min: -180, max: 180 }],


### PR DESCRIPTION
J'en ai profité pour virer le stacking context au niveau de la dropdown, ce qui permet au contenu d'une dropdown de bien passé au dessus du trigger d'une autre dropdown