### PR TITLE
Add capture event for the dropdown to process its own logic before th…

### DIFF
--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -4,7 +4,7 @@
             :style="{ display: !isMenuDisplayed ? 'block' : 'none' }"
             class="dropdown-default"
             ww-responsive="dropdown-desktop"
-            @click="handleClickInside"
+            @click.capture="handleClickInside"
             @mouseenter="handleMouseHover(true)"
             @mouseleave="handleMouseHover(false)"
         >


### PR DESCRIPTION
…e event captured by sub element

The WW-3109 branch have to be merged to be able to test this fix

Explanations : All clic event are captured by children (button, etc) and so, the handleClickInside logic is not triggered in these cases. Add the capture mode will trigger the handleClickInside method before the clic event is passing to children